### PR TITLE
split run method not to use parse args for flask app

### DIFF
--- a/backend_jobs/ingestion_pipeline/main.py
+++ b/backend_jobs/ingestion_pipeline/main.py
@@ -41,12 +41,12 @@ def _generate_image_id(image):
     return image
 
 
-def _validate_args(args):
+def _validate_args(input_provider_name):
     """ Checks whether the pipeline's arguments are valid.
     If not - throws an error.
 
     """
-    if not isinstance(args.input_provider_name, str):
+    if not isinstance(input_provider_name, str):
         raise ValueError('ingestion provider is not a string')
 
 
@@ -62,24 +62,7 @@ def _is_valid_image(image):
         image.width_pixels > 100 and \
         image.height_pixels > 100
 
-
-def run(argv=None):
-    """Main entry point,  defines and runs the image ingestion pipeline.
-
-    Input:
-        input_provider_name- the image provider to ingest images from.
-        input_provider_args- optional query to pass to the image provider.
-        e.g 'tags:cat,dog-tag_mode:any'.
-
-        Additional parameters that are being forwarded to the PipelineOptions:
-        region- The rigion the job runs, e.g. europe-west2.
-        output- Where to save the outpot, e.g. outputs.txt.
-        runner- The runner of the job, e.g. DataflowRunner.
-        project- Project id, e.g. step-project-ellispis.
-        requirements_file- A file with all externall imports, e.g. requirements.txt.
-        extra_package- A zip file with all internal import packages,
-        e.g. pipeline-BACKEND_JOBS-0.0.1.tar.gz.
-    """
+def parse_arguments():
     # Using external parser: https://docs.python.org/3/library/argparse.html
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -97,19 +80,46 @@ def run(argv=None):
         dest='output',
         required=False,  # Optional - only for development reasons.
         help='Output file to write results to.')
+    return parser.parse_known_args()
 
-    known_args, pipeline_args = parser.parse_known_args(argv)
-    _validate_args(known_args)
+def run(input_provider_name, input_provider_args=None, output_name=None, run_locally=False):
+    """Main entry point,  defines and runs the image ingestion pipeline.
+
+    Input:
+        input_provider_name- the image provider to ingest images from.
+        input_provider_args- optional query to pass to the image provider.
+        e.g 'tags:cat,dog-tag_mode:any'.
+
+        Additional parameters that are being forwarded to the PipelineOptions:
+        region- The rigion the job runs, e.g. europe-west2.
+        output- Where to save the outpot, e.g. outputs.txt.
+        runner- The runner of the job, e.g. DataflowRunner.
+        project- Project id, e.g. step-project-ellispis.
+        requirements_file- A file with all externall imports, e.g. requirements.txt.
+        extra_package- A zip file with all internal import packages,
+        e.g. pipeline-BACKEND_JOBS-0.0.1.tar.gz.
+    """
+    _validate_args(input_provider_name)
     image_provider = providers.get_provider(
         providers.IMAGE_PROVIDERS,
-        known_args.input_provider_name,
-        known_args.input_provider_args)
+        input_provider_name,
+        input_provider_args)
 
     if not image_provider.enabled:
         raise ValueError('ingestion provider is not enabled')
 
     job_name = utils.generate_cloud_dataflow_job_name('ingestion', image_provider)
-    pipeline_options = PipelineOptions(pipeline_args, job_name=job_name)
+    if run_locally:
+        pipeline_options = PipelineOptions()
+    else:
+        pipeline_options = PipelineOptions(
+            flags=None,
+            runner='DataflowRunner',
+            project='step-project-ellispis',
+            job_name=job_name,
+            temp_location='gs://demo-bucket-step/temp',
+            region='europe-west2',
+        )
 
     # The pipeline will be run on exiting the with block.
     # pylint: disable=expression-not-assigned
@@ -130,12 +140,14 @@ def run(argv=None):
         generate_image_id | 'store_image' >> \
             apache_beam.ParDo(firestore_database.AddOrUpdateImageDoFn(), image_provider, job_name)
 
-        if known_args.output:
-            generate_image_id | 'Write' >> WriteToText(known_args.output)
+        if output_name:
+            generate_image_id | 'Write' >> WriteToText(output_name)
 
     store_pipeline_run(image_provider.provider_id, job_name)
 
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.INFO)
-    run()
+    args, pipeline_args = parse_arguments()
+    run(args.input_provider_name, args.input_provider_args, args.output, run_locally=True)
+    

--- a/backend_jobs/recognition_pipeline/main.py
+++ b/backend_jobs/recognition_pipeline/main.py
@@ -36,29 +36,23 @@ from backend_jobs.recognition_pipeline.providers.providers import get_recognitio
 
 _PIPELINE_TYPE = 'recognition'
 
-def _validate_args(args):
+def _validate_args(recognition_provider, ingestion_pipelinerun_id, ingestion_provider ):
     """ Checks whether the pipeline's arguments are valid.
     If not - throws an error.
 
     """
-    if bool(args.input_ingestion_pipelinerun_id) == bool(args.input_ingestion_provider):
+    if bool(ingestion_pipelinerun_id) == bool(ingestion_provider):
         raise ValueError('pipeline requires exactly one of out of ingestion pipeline run \
             and ingestion provider - zero or two were given')
-    if args.input_ingestion_pipelinerun_id and\
-        not isinstance(args.input_ingestion_pipelinerun_id, str):
+    if ingestion_pipelinerun_id and\
+        not isinstance(ingestion_pipelinerun_id, str):
         raise ValueError('ingestion pipeline run id is not a string')
-    if args.input_ingestion_provider and not isinstance(args.input_ingestion_provider, str):
+    if ingestion_provider and not isinstance(ingestion_provider, str):
         raise ValueError('ingestion pipeline provider id is not a string')
-    if not isinstance(args.input_recognition_provider, str):
+    if not isinstance(recognition_provider, str):
         raise ValueError('recognition provider is not a string')
 
-def run(argv=None):
-    """Main entry point, defines and runs the image recognition pipeline.
-
-    Input: either ingestion run id or ingestion provider id.
-    The input is used for querying the database for image ingested by
-    either one of the optional inputs.
-    """
+def parse_arguments():
     # Using external parser: https://docs.python.org/3/library/argparse.html
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -79,17 +73,30 @@ def run(argv=None):
         dest='output',
         required = False, # Optional - only for development reasons.
         help='Output file to write results to for testing.')
-    known_args, pipeline_args = parser.parse_known_args(argv)
-    _validate_args(known_args)
-    ingestion_run = known_args.input_ingestion_pipelinerun_id
-    ingestion_provider = known_args.input_ingestion_provider
-    # Creating an object of type ImageRecognitionProvider
-    # for the specific image recognition provider input.
-    recognition_provider = get_recognition_provider(known_args.input_recognition_provider)
-    job_name = generate_cloud_dataflow_job_name(_PIPELINE_TYPE, recognition_provider)
-    pipeline_options = PipelineOptions(pipeline_args, job_name=job_name)
+    return parser.parse_known_args()
 
-    with beam.Pipeline(options=pipeline_options) as pipeline:
+def run(recognition_provider_name, ingestion_run, ingestion_provider, output_name=None, run_locally=False):
+    """Main entry point, defines and runs the image recognition pipeline.
+
+    Input: either ingestion run id or ingestion provider id.
+    The input is used for querying the database for image ingested by
+    either one of the optional inputs.
+    """
+    _validate_args(recognition_provider_name, ingestion_run, ingestion_provider)
+    recognition_provider = get_recognition_provider(recognition_provider_name)
+    job_name = generate_cloud_dataflow_job_name(_PIPELINE_TYPE, recognition_provider)
+    if run_locally:
+        recognition_options = PipelineOptions()
+    else:
+        recognition_options = PipelineOptions(
+        flags=None,
+        runner='DataflowRunner',
+        project='step-project-ellispis',
+        job_name=job_name,
+        temp_location='gs://demo-bucket-step/temp',
+        region='europe-west2',
+        )
+    with beam.Pipeline(options=recognition_options) as pipeline:
         indices_for_batching = pipeline | 'create' >> beam.Create([i for i in range(10)])
         if ingestion_run:
             dataset = indices_for_batching | 'get images dataset' >> \
@@ -113,13 +120,18 @@ def run(argv=None):
         labeled_images | 'store in database' >> beam.ParDo(UpdateImageLabelsInDatabase(),\
             job_name, recognition_provider.provider_id)
 
-        if known_args.output: # For testing.
+        if output_name: # For testing.
             def format_result(image, labels):
                 return '%s: %s' % (image['url'], labels)
             output = labeled_images | 'Format' >> beam.MapTuple(format_result)
-            output | 'Write' >> WriteToText(known_args.output)
+            output | 'Write' >> WriteToText(output_name)
     store_pipeline_run(recognition_provider.provider_id, job_name)
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.INFO)
-    run()
+    args, pipeline_args = parse_arguments()
+    input_ingestion_run = args.input_ingestion_pipelinerun_id
+    input_ingestion_provider = args.input_ingestion_provider
+    input_recognition_provider = args.input_recognition_provider
+    test_output = args.output
+    run(input_recognition_provider, input_ingestion_run, input_ingestion_provider, test_output, True)

--- a/backend_jobs/recognition_pipeline/main.py
+++ b/backend_jobs/recognition_pipeline/main.py
@@ -75,7 +75,7 @@ def parse_arguments():
         help='Output file to write results to for testing.')
     return parser.parse_known_args()
 
-def run(recognition_provider_name, ingestion_run, ingestion_provider, output_name=None, run_locally=False):
+def run(recognition_provider_name, ingestion_run=None, ingestion_provider=None, output_name=None, run_locally=False):
     """Main entry point, defines and runs the image recognition pipeline.
 
     Input: either ingestion run id or ingestion provider id.
@@ -130,8 +130,4 @@ def run(recognition_provider_name, ingestion_run, ingestion_provider, output_nam
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.INFO)
     args, pipeline_args = parse_arguments()
-    input_ingestion_run = args.input_ingestion_pipelinerun_id
-    input_ingestion_provider = args.input_ingestion_provider
-    input_recognition_provider = args.input_recognition_provider
-    test_output = args.output
-    run(input_recognition_provider, input_ingestion_run, input_ingestion_provider, test_output, True)
+    run(args.input_recognition_provider, args.input_ingestion_pipelinerun_id, args.input_ingestion_provider, args.output, run_locally=True)


### PR DESCRIPTION
made an example for recognition pipeline to split the run method from parse args in order to use only the run method in the flask app. We want to verify it's good before changing all pipelines.